### PR TITLE
Add education section to resume layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,23 @@ li {
         </div>
     </div>
 
+    <!-- Education -->
+    <div class="section">
+        <div class="section-title">Education</div>
+        <ul>
+            <li>
+                <strong>Bachelor of Science in Computer Science</strong>, University of Khartoum — 2018
+                <br>Graduated with Honors; Senior Project: <em>Cloud-Based ERP for SMEs</em>
+                <br><span>Relevant Coursework: Distributed Systems, Database Design, Software Engineering, Data Structures</span>
+            </li>
+            <li>
+                <strong>Diploma in Information Technology</strong>, Sudan University of Science and Technology — 2014
+                <br>Focus on full-stack web development and mobile application design
+                <br><span>Achievements: Dean's List (2013 & 2014), Led student tech club hackathon team</span>
+            </li>
+        </ul>
+    </div>
+
    <!-- Certifications & Courses -->
 <div class="section">
     <div class="section-title">Certifications & Courses</div>


### PR DESCRIPTION
## Summary
- add a dedicated Education section between Experience and Certifications
- outline academic credentials with degree details, institutions, graduation years, and achievements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db848f468c832891918fbda12b8067