### PR TITLE
Add education section to both resume layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,19 @@ li {
         </div>
     </div>
 
+    <div class="section">
+        <div class="section-title">Education</div>
+        <div class="experience-item">
+            <div class="job-title">B.Sc. in Computer Science</div>
+            <div class="company">Sudan University of Science and Technology</div>
+            <div class="date">Graduated: 2018 | Khartoum, Sudan</div>
+            <ul>
+                <li>Graduated with honors, focusing on software engineering and systems design.</li>
+                <li>Key coursework: Distributed Systems, Database Management, Algorithms, and Software Engineering.</li>
+            </ul>
+        </div>
+    </div>
+
    <!-- Certifications & Courses -->
 <div class="section">
     <div class="section-title">Certifications & Courses</div>

--- a/index_2.html
+++ b/index_2.html
@@ -360,6 +360,20 @@
     </div>
 
 
+    <div class="section">
+        <div class="section-title">Education</div>
+        <div class="experience-item">
+            <div class="job-title">B.Sc. in Computer Science</div>
+            <div class="company">Sudan University of Science and Technology</div>
+            <div class="date">Graduated: 2018 | Khartoum, Sudan</div>
+            <ul>
+                <li>Graduated with honors with a focus on software engineering and distributed systems.</li>
+                <li>Key coursework: Algorithms, Database Management, Distributed Systems, and Software Engineering.</li>
+            </ul>
+        </div>
+    </div>
+
+
     <!-- Certifications -->
     <div class="section">
         <div class="section-title">Certifications & Courses</div>


### PR DESCRIPTION
## Summary
- add an Education section before Certifications in both resume HTML files
- detail the computer science degree with graduation date, honors, and key coursework

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db84878d548328b8ff676856f6aa6d