### PR TITLE
Remove Meta certification entry with duplicate URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,9 +389,6 @@
             <li><strong>Odoo Functional Certification</strong> – ERP development & customization |
                 <a href="https://www.odoo.com/slides/odoo-certification-sample-test-50">View</a>
             </li>
-            <li><strong>Introduction to Back-End Development</strong> (Meta) – APIs & databases |
-                <a href="https://www.coursera.org/account/accomplishments/verify/QATJPNBDZWGP">View</a>
-            </li>
         </ul>
     </div>
 


### PR DESCRIPTION
## Summary
- remove the Meta Introduction to Back-End Development certification entry because it shared an incorrect verification link with the AWS Fundamentals item
- ensure each listed certification now points to a unique verification URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db8aa923548328a483833283ca9656